### PR TITLE
Ten stage error investigation and github actions verification

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -38,8 +38,8 @@ jobs:
       - name: 📱 Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          components: platform-tools, platforms;android-34, build-tools;34.0.0
+          api-level: 35
+          components: platform-tools, platforms;android-35, build-tools;35.0.0
 
 
       - name: 🗃️ Cache Gradle
@@ -59,10 +59,10 @@ jobs:
         uses: gradle/wrapper-validation-action@v1
 
       - name: 🏗️ Build Debug APK
-        run: ./gradlew assembleDebug --build-cache
+        run: ./gradlew :android:app:assembleDebug --build-cache
 
       - name: 🏗️ Build Release APK
-        run: ./gradlew assembleRelease --build-cache
+        run: ./gradlew :android:app:assembleRelease --build-cache
 
       - name: 📱 Upload Debug APK
         uses: actions/upload-artifact@v4
@@ -120,8 +120,8 @@ jobs:
       - name: 📱 Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          components: platform-tools, platforms;android-34, build-tools;34.0.0
+          api-level: 35
+          components: platform-tools, platforms;android-35, build-tools;35.0.0
 
 
       - name: 🗃️ Cache Gradle
@@ -303,8 +303,8 @@ jobs:
       - name: 📱 Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          components: platform-tools, platforms;android-34, build-tools;34.0.0
+          api-level: 35
+          components: platform-tools, platforms;android-35, build-tools;35.0.0
 
       - name: 🗃️ Cache Gradle
         uses: actions/cache@v4
@@ -358,8 +358,8 @@ jobs:
       - name: 📱 Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          components: platform-tools, platforms;android-34, build-tools;34.0.0
+          api-level: 35
+          components: platform-tools, platforms;android-35, build-tools;35.0.0
 
       - name: 🗃️ Cache Gradle
         uses: actions/cache@v4

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -47,8 +47,8 @@ jobs:
       - name: 📱 Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          components: platform-tools, platforms;android-34, build-tools;34.0.0
+          api-level: 35
+          components: platform-tools, platforms;android-35, build-tools;35.0.0
 
       - name: 🗃️ Setup Gradle Cache
         uses: actions/cache@v4
@@ -169,8 +169,8 @@ jobs:
       - name: 📱 Setup Android SDK
         uses: android-actions/setup-android@v3
         with:
-          api-level: 34
-          components: platform-tools, platforms;android-34, build-tools;34.0.0
+          api-level: 35
+          components: platform-tools, platforms;android-35, build-tools;35.0.0
 
       - name: 🗃️ Restore Gradle Cache
         uses: actions/cache@v4


### PR DESCRIPTION
Update GitHub Actions to Android API 35 and target the app module to fix CI build failures and align with project SDK versions.

The CI workflows were configured to use Android API 34 and build-tools 34.0.0, which mismatched the project's `compileSdk=35` and `targetSdk=35`. This caused build-tool version mismatch errors. Additionally, `android.yml` was attempting to build the entire project with `assembleDebug/Release` instead of targeting the specific `:android:app` module, leading to potential build issues. These changes resolve these discrepancies, ensuring successful and correct APK generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-8305214c-5447-4666-9ce3-25bbe5afb58a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8305214c-5447-4666-9ce3-25bbe5afb58a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

